### PR TITLE
a couple small fixes

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+inventory=inventory

--- a/apply.yml
+++ b/apply.yml
@@ -5,6 +5,6 @@
     ci_cd_namespace: <YOUR_NAME>-ci-cd
     dev_namespace: <YOUR_NAME>-dev
     test_namespace: <YOUR_NAME>-test
-  tasks:
-    - include_role:
-        name: openshift-applier/roles/openshift-applier
+  
+  roles:
+    - { role: openshift-applier/roles/openshift-applier }

--- a/notes.txt
+++ b/notes.txt
@@ -1,0 +1,2 @@
+1. Having inventory specified in ansible.cfg means that playbook invocations don't have to run -i inventory
+2. Calling a role directly has a number of benefits, but mainly is important because this is how the documentation does it. Inclue and import should be reserved for cases like looking over roles

--- a/notes.txt
+++ b/notes.txt
@@ -1,2 +1,0 @@
-1. Having inventory specified in ansible.cfg means that playbook invocations don't have to run -i inventory
-2. Calling a role directly has a number of benefits, but mainly is important because this is how the documentation does it. Inclue and import should be reserved for cases like looking over roles


### PR DESCRIPTION
1. Having inventory specified in ansible.cfg means that playbook invocations don't have to run -i inventory --- (Issue: Add ansible.cfg #11)
***note: the lab documentation playbook commands could be edited as well if this is merged

2. Mainly is important for customers because this is how the Ansible Docs do it. Include_role and import_role are typically reserved for edge cases like looping over roles --- (Call roles directly instead of using include_role #12)