### PR TITLE
Updated to use 'openshift-applier' v2.0.0

### DIFF
--- a/inventory/host_vars/projects-and-policies.yml
+++ b/inventory/host_vars/projects-and-policies.yml
@@ -5,7 +5,7 @@ openshift_cluster_content:
   content:
   - name: "{{ ci_cd_namespace }}"
     template: "{{ playbook_dir }}/templates/project-requests.yml"
-    template_action: create
+    action: create
     params: "{{ playbook_dir }}/params/project-requests-ci-cd"
     tags:
     - projects

--- a/requirements.yml
+++ b/requirements.yml
@@ -4,5 +4,5 @@
 # From 'openshift-applier'
 - src: https://github.com/redhat-cop/openshift-applier
   scm: git
-  version: v3.7.2
+  version: v2.0.0
   name: openshift-applier


### PR DESCRIPTION
Updating to use the latest [v2.0.0](https://github.com/redhat-cop/openshift-applier/releases/tag/v2.0.0) version of the [openshift-applier](https://github.com/redhat-cop/openshift-applier).