### PR TITLE
apiVersion missing from SecurityContextConstraints

### DIFF
--- a/templates/gitlab.yml
+++ b/templates/gitlab.yml
@@ -14,6 +14,7 @@ labels:
   createdBy: gitlab-ce-template
 objects:
 - kind: SecurityContextConstraints
+  apiVersion: v1
   metadata:
     annotations:
       kubernetes.io/description: anyuid provides all features of the restricted SCC


### PR DESCRIPTION
`apiVersion` was missing from the `SecurityContextConstraints` object.