### PR TITLE
Repository rhel-7-server-htb-rpms not found

### DIFF
--- a/docker/jenkins-slave-arachni/Dockerfile
+++ b/docker/jenkins-slave-arachni/Dockerfile
@@ -3,7 +3,7 @@ FROM openshift/jenkins-slave-base-centos7:latest
 ARG VERSION=1.5.1
 ARG WEB_VERSION=0.5.12
 
-RUN yum install --disablerepo=rhel-7-server-htb-rpms -y wget ca-certificates
+RUN yum install -y wget ca-certificates
 
 WORKDIR /arachni
 


### PR DESCRIPTION
```

Step 5/14 : RUN yum install --disablerepo=rhel-7-server-htb-rpms -y wget ca-certificates
--
  | ---> Running in d1e8dddb5ba2
  |  
  | Loaded plugins: ovl, product-id, search-disabled-repos, subscription-manager
  |  
  |  
  | Error getting repository data for rhel-7-server-htb-rpms, repository not found
  | Removing intermediate container d1e8dddb5ba2
  | error: build error: The command '/bin/sh -c yum install --disablerepo=rhel-7-server-htb-rpms -y wget ca-certificates' returned a non-zero code: 1
```