### PR TITLE
applier version bumped

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -4,5 +4,5 @@
 # From 'openshift-applier'
 - src: https://github.com/redhat-cop/openshift-applier
   scm: git
-  version: v2.0.10
+  version: v2.1.2
   name: openshift-applier


### PR DESCRIPTION
Ansible applier version's bumped to work with Openshift 4.x client.